### PR TITLE
When there isn't an oldest node due to role restrictions, down unreac…

### DIFF
--- a/src/Akka.Cluster.SplitBrainResolver/KeepOldestDowningStrategy.cs
+++ b/src/Akka.Cluster.SplitBrainResolver/KeepOldestDowningStrategy.cs
@@ -40,10 +40,10 @@ namespace Akka.Cluster.SplitBrainResolver
                 (haveOldest && available.Count == 1)
                 || (!haveOldest && available.Count == clusterState.GetMembers(Role).Count - 1);
 
-            if(oldest == null)
-                return Enumerable.Empty<Member>();
+            if (oldest == null)
+                return clusterState.GetUnreachableMembers();
 
-            if(oldestIsAlone && DownIfAlone)
+            if (oldestIsAlone && DownIfAlone)
                 return new List<Member> { oldest };
 
             return haveOldest


### PR DESCRIPTION
…hable nodes